### PR TITLE
Filter out subgraphs with invalid manifest

### DIFF
--- a/src/store/subgraphs.js
+++ b/src/store/subgraphs.js
@@ -37,7 +37,11 @@ export const useSubgraphsStore = defineStore({
     },
     getFilteredSubgraphs: (state) => {
       let subgraphs = state.getSubgraphs;
-      
+
+      subgraphs = subgraphs.filter((i) => {
+        return i.currentVersion.subgraphDeployment.manifest !== null;
+      });
+
       if(subgraphSettingStore.settings.noRewardsFilter === 0){
         subgraphs = subgraphs.filter((i) => {
           return !i.currentVersion.subgraphDeployment.deniedAt;


### PR DESCRIPTION
Started getting the following error out of nowhere:

```
index.1fad6750.js:4 TypeError: Cannot read properties of null (reading 'network')
    at subgraphs.a14b316d.js:1:757
    at Array.filter (<anonymous>)
    at Proxy.getFilteredSubgraphs (subgraphs.a14b316d.js:1:702)
    at index.1fad6750.js:16:1446
    at xs.fn (index.1fad6750.js:1:10491)
    at xs.run (index.1fad6750.js:1:2735)
    at get value (index.1fad6750.js:1:10713)
    at oh.get (index.1fad6750.js:1:5977)
    at Proxy.<anonymous> (SubgraphsDashboard.b754196b.js:1:2804)
    at La (index.1fad6750.js:4:5353)
```

After a bit of digging I found this "subgraph" to be the culprit: https://thegraph.com/explorer/subgraphs/FGfi3KdCAKLsiUA8sxQQJdyNCuyKKj3BvgqVFLiYdpvd?view=Query&chain=arbitrum-one

Fix is a bit dirty but it works, feel free to dismiss and do something else if there is a cleaner way.