### PR TITLE
feat: support Graph Horizon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 /dist
 
 # local env files
+.env
 .env.local
 .env.*.local
 

--- a/indexer-tools-config.json.example
+++ b/indexer-tools-config.json.example
@@ -2,8 +2,8 @@
   "DEFAULT_ACCOUNTS": [ { "address": "0x1b92e4cba0f82c85c1298af861247849988c788c", "name": "vincenttaglia-indexer.eth", "active": true, "chain": "arbitrum-one", "agentConnect": false, "agentEndpoint": "", "poiQuery": false, "poiQueryEndpoint": "" } ],
   "DEFAULT_RPC_MAINNET": "https://mainnet.infura.io/v3/659344f230804542a4e653f875172105",
   "DEFAULT_RPC_ARBITRUM": "https://arb-mainnet.g.alchemy.com/v2/er8LBcXpoFwlV8xJee-WXFbFG_M8L4JK",
-  "DEFAULT_RPC_SEPOLIA": "https://eth-sepolia.g.alchemy.com/v2/eKJ8_13LMaVi2bSITYWTMqskgsGiey8K"
-  "DEFAULT_RPC_ARBITRUM_SEPOLIA": "https://arbitrum-sepolia.infura.io/v3/db92de7c459f4d83a2c2c21931a6bdf0"
+  "DEFAULT_RPC_SEPOLIA": "https://eth-sepolia.g.alchemy.com/v2/eKJ8_13LMaVi2bSITYWTMqskgsGiey8K",
+  "DEFAULT_RPC_ARBITRUM_SEPOLIA": "https://arbitrum-sepolia.infura.io/v3/db92de7c459f4d83a2c2c21931a6bdf0",
   "DEFAULT_SUBGRAPH_MAINNET": "https://gateway.thegraph.com/api/[api-key]/subgraphs/id/9Co7EQe5PgW3ugCUJrJgRv4u9zdEuDJf8NvMWftNsBH8",
   "DEFAULT_SUBGRAPH_ARBITRUM": "https://gateway.thegraph.com/api/[api-key]/subgraphs/id/DZz4kDTdmzWLWsV373w2bSmoar3umKKH9y82SUKr5qmp",
   "DEFAULT_SUBGRAPH_SEPOLIA": "https://gateway.thegraph.com/api/[api-key]/subgraphs/id/8pVKDwHniAz87CHEQsiz2wgFXGZXrbMDkrxgauVVfMJC",

--- a/server.js
+++ b/server.js
@@ -2,8 +2,11 @@ const express = require('express');
 var history = require('connect-history-api-fallback');
 const serveStatic = require("serve-static")
 const path = require('path');
-app = express();
+
+let app = express();
 app.use(history());
 app.use(serveStatic(path.join(__dirname, 'dist')));
 const port = process.env.PORT || 3000;
-app.listen(port);
+app.listen(port, () => {
+  console.log(`Indexer Tools v3 is running on port ${port}`);
+});

--- a/src/components/CustomPOISetter.vue
+++ b/src/components/CustomPOISetter.vue
@@ -290,6 +290,38 @@
             Query POI
           </v-btn>
         </td>
+        <td>
+          <v-text-field 
+              class="mt-4 pt-0"
+              style="width: 200px"
+              v-model="customBlockHeights[item.subgraphDeployment.ipfsHash]"
+              hint="Manual POI Block Height"
+          ></v-text-field>
+        </td>
+        <td>
+          <v-btn 
+           v-if="accountStore.getActiveAccount.poiQuery && item.deploymentStatus?.fatalError" 
+           @click="queryPOIBlockHeight(item.subgraphDeployment.ipfsHash, item.deploymentStatus?.fatalError?.block?.number, item.deploymentStatus?.fatalError?.block?.hash)"
+          >
+            Query POI Block Height
+          </v-btn>
+        </td>
+        <td>
+          <v-text-field 
+              class="mt-4 pt-0"
+              style="width: 250px"
+              v-model="customPublicPOIs[item.subgraphDeployment.ipfsHash]"
+              hint="Manual Public POI"
+          ></v-text-field>
+        </td>
+        <td>
+          <v-btn 
+           v-if="accountStore.getActiveAccount.poiQuery && item.deploymentStatus?.fatalError" 
+           @click="queryPublicPOI(item.subgraphDeployment.ipfsHash, item.deploymentStatus?.fatalError?.block?.number, item.deploymentStatus?.fatalError?.block?.hash)"
+          >
+            Query Public POI
+          </v-btn>
+        </td>
       </tr>
       
     </template>
@@ -319,7 +351,7 @@ const { getActiveAccount } = storeToRefs(accountStore);
 
 const { selected, loaded } = storeToRefs(allocationStore);
 
-const { customPOIs } = storeToRefs(newAllocationSetterStore);
+const { customPOIs, customPublicPOIs, customBlockHeights } = storeToRefs(newAllocationSetterStore);
 
 defineProps({
   selectable: {
@@ -366,5 +398,21 @@ async function queryPOI(QmHash, block, blockHash){
     .then((json) => {
       newAllocationSetterStore.customPOIs[QmHash] = json.data.proofOfIndexing;
     });
+}
+
+async function queryPublicPOI(QmHash, block, blockHash){
+  fetch(accountStore.getActiveAccount.poiQueryEndpoint,  {
+      method: "POST",
+      headers: {"Content-type": "application/json"},
+      body: JSON.stringify({query: `{ proofOfIndexing(blockNumber: ${block}, blockHash: "${blockHash}", subgraph: "${QmHash}", indexer: "0x0000000000000000000000000000000000000000") }`}),
+    })
+    .then((res) => res.json())
+    .then((json) => {
+      newAllocationSetterStore.customPublicPOIs[QmHash] = json.data.proofOfIndexing;
+    });
+}
+
+async function queryPOIBlockHeight(QmHash, block, blockHash){
+  newAllocationSetterStore.customBlockHeights[QmHash] = block;
 }
 </script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -59,7 +59,7 @@ const routes = [
 ]
 
 const router = createRouter({
-  history: createWebHistory(process.env.BASE_URL),
+  history: createWebHistory(import.meta.env.BASE_URL),
   routes,
 })
 

--- a/src/store/allocations.js
+++ b/src/store/allocations.js
@@ -470,7 +470,6 @@ export const useAllocationStore = defineStore('allocationStore', {
         this.fetch(0)
         .then((data) => {
           console.log(data);
-          console.log("ALLOCATIONs")
           this.allocations = data.allocations;
           this.pendingRewards = Array(data.allocations.length).fill();
           for(let i = 0; i < this.pendingRewards.length; i++){

--- a/src/store/allocations.js
+++ b/src/store/allocations.js
@@ -470,6 +470,7 @@ export const useAllocationStore = defineStore('allocationStore', {
         this.fetch(0)
         .then((data) => {
           console.log(data);
+          console.log("ALLOCATIONs")
           this.allocations = data.allocations;
           this.pendingRewards = Array(data.allocations.length).fill();
           for(let i = 0; i < this.pendingRewards.length; i++){
@@ -526,6 +527,7 @@ export const useAllocationStore = defineStore('allocationStore', {
             indexingRewards
             indexingIndexerRewards
             indexingDelegatorRewards
+            isLegacy
           }
   
         }`,

--- a/src/store/network.js
+++ b/src/store/network.js
@@ -55,7 +55,7 @@ export const useNetworkStore = defineStore('network', {
     getIssuancePerBlock: (state) => state.networks[chainStore.getChainID].issuancePerBlock,
     getIssuancePerYear: (state) => state.networks[chainStore.getChainID].issuancePerYear,
     getTotalTokensAllocated: (state) => state.networks[chainStore.getChainID].totalTokensAllocated,
-    isNetworkHorizon: (state) => state.networks[chainStore.getChainID].maxThawingPeriod > 0,
+    isNetworkHorizon: (state) => parseInt(state.networks[chainStore.getChainID].maxThawingPeriod) > 0,
   },
   actions: {
     async init(){

--- a/src/store/network.js
+++ b/src/store/network.js
@@ -55,6 +55,7 @@ export const useNetworkStore = defineStore('network', {
     getIssuancePerBlock: (state) => state.networks[chainStore.getChainID].issuancePerBlock,
     getIssuancePerYear: (state) => state.networks[chainStore.getChainID].issuancePerYear,
     getTotalTokensAllocated: (state) => state.networks[chainStore.getChainID].totalTokensAllocated,
+    isNetworkHorizon: (state) => state.networks[chainStore.getChainID].maxThawingPeriod > 0,
   },
   actions: {
     async init(){
@@ -67,6 +68,7 @@ export const useNetworkStore = defineStore('network', {
             totalSupply
             currentEpoch
             totalTokensAllocated
+            maxThawingPeriod
           }
         }`,
       }).then((data) => {
@@ -77,6 +79,7 @@ export const useNetworkStore = defineStore('network', {
         this.networks[chain.id].currentEpoch = data.data.graphNetwork.currentEpoch;
         this.networks[chain.id].issuancePerYear = data.data.graphNetwork.networkGRTIssuancePerBlock * chainStore.getBlocksPerYear;
         this.networks[chain.id].totalTokensAllocated = data.data.graphNetwork.totalTokensAllocated;
+        this.networks[chain.id].maxThawingPeriod = data.data.graphNetwork.maxThawingPeriod;
       }).catch((err) => {
         this.loading = false;
         if(err.graphQLErrors[0]?.message){

--- a/src/store/newAllocationSetter.js
+++ b/src/store/newAllocationSetter.js
@@ -20,6 +20,8 @@ export const useNewAllocationSetterStore = defineStore('allocationSetter', {
     minAllocation: 0,
     minAllocation0Signal: 0,
     customPOIs: {},
+    customBlockHeights: {},
+    customPublicPOIs: {},
   }),
   getters: {
     getSelected: () => subgraphStore.selected,
@@ -209,9 +211,9 @@ export const useNewAllocationSetterStore = defineStore('allocationSetter', {
         let customPOI = "";
         if(state.customPOIs[allocationStore.getSelectedAllocations[i].subgraphDeployment.ipfsHash]){
           if(state.customPOIs[allocationStore.getSelectedAllocations[i].subgraphDeployment.ipfsHash] == "0x0"){
-            customPOI = "0x0000000000000000000000000000000000000000 true ";
+            customPOI = "0x0000000000000000000000000000000000000000000000000000000000000000 true 0 0x0000000000000000000000000000000000000000000000000000000000000000 ";
           } else{
-            customPOI = `${state.customPOIs[allocationStore.getSelectedAllocations[i].subgraphDeployment.ipfsHash]} true `;
+            customPOI = `${state.customPOIs[allocationStore.getSelectedAllocations[i].subgraphDeployment.ipfsHash]} true ${state.customBlockHeights[allocationStore.getSelectedAllocations[i].subgraphDeployment.ipfsHash]} ${state.customPublicPOIs[allocationStore.getSelectedAllocations[i].subgraphDeployment.ipfsHash]} `;
           }
         }
         if(subgraphStore.selected.includes(allocationStore.getSelectedAllocations[i].subgraphDeployment.ipfsHash)){
@@ -271,6 +273,8 @@ export const useNewAllocationSetterStore = defineStore('allocationSetter', {
           }
           if(state.customPOIs[allocationStore.getSelectedAllocations[i].subgraphDeployment.ipfsHash]){
             allo.poi = state.customPOIs[allocationStore.getSelectedAllocations[i].subgraphDeployment.ipfsHash]
+            allo.poiBlockNumber = parseInt(state.customBlockHeights[allocationStore.getSelectedAllocations[i].subgraphDeployment.ipfsHash])
+            allo.publicPOI = state.customPublicPOIs[allocationStore.getSelectedAllocations[i].subgraphDeployment.ipfsHash]
             allo.force = true;
           }
           reallocate.push(allo);
@@ -290,8 +294,12 @@ export const useNewAllocationSetterStore = defineStore('allocationSetter', {
           if(state.customPOIs[allocationStore.getSelectedAllocations[i].subgraphDeployment.ipfsHash]){
             if(state.customPOIs[allocationStore.getSelectedAllocations[i].subgraphDeployment.ipfsHash] == "0x0"){
               allo.poi = "0x0000000000000000000000000000000000000000000000000000000000000000";
+              allo.poiBlockNumber = 0 ;
+              allo.publicPOI = "0x0000000000000000000000000000000000000000000000000000000000000000";
             } else{
               allo.poi = state.customPOIs[allocationStore.getSelectedAllocations[i].subgraphDeployment.ipfsHash]
+              allo.poiBlockNumber = parseInt(state.customBlockHeights[allocationStore.getSelectedAllocations[i].subgraphDeployment.ipfsHash])
+              allo.publicPOI = state.customPublicPOIs[allocationStore.getSelectedAllocations[i].subgraphDeployment.ipfsHash]
             }
             allo.force = true;
           }

--- a/src/store/newAllocationSetter.js
+++ b/src/store/newAllocationSetter.js
@@ -253,6 +253,7 @@ export const useNewAllocationSetterStore = defineStore('allocationSetter', {
               source: 'Indexer Tools - Agent Connect',
               reason: 'Allocation Wizard',
               priority: 1,
+              isLegacy: allocationStore.getSelectedAllocations[i].isLegacy,
             };
           } else{
             allo = {
@@ -265,6 +266,7 @@ export const useNewAllocationSetterStore = defineStore('allocationSetter', {
               source: 'Indexer Tools - Agent Connect',
               reason: 'Allocation Wizard',
               priority: 2,
+              isLegacy: allocationStore.getSelectedAllocations[i].isLegacy,
             };
           }
           if(state.customPOIs[allocationStore.getSelectedAllocations[i].subgraphDeployment.ipfsHash]){
@@ -283,6 +285,7 @@ export const useNewAllocationSetterStore = defineStore('allocationSetter', {
             source: 'Indexer Tools - Agent Connect',
             reason: 'Allocation Wizard',
             priority: 1,
+            isLegacy: allocationStore.getSelectedAllocations[i].isLegacy,
           };
           if(state.customPOIs[allocationStore.getSelectedAllocations[i].subgraphDeployment.ipfsHash]){
             if(state.customPOIs[allocationStore.getSelectedAllocations[i].subgraphDeployment.ipfsHash] == "0x0"){
@@ -306,6 +309,7 @@ export const useNewAllocationSetterStore = defineStore('allocationSetter', {
             source: 'Indexer Tools - Agent Connect',
             reason: 'Allocation Wizard',
             priority: 2,
+            isLegacy: !networkStore.isNetworkHorizon,
           });
         }
           

--- a/src/views/ActionQueueManager.vue
+++ b/src/views/ActionQueueManager.vue
@@ -338,6 +338,8 @@ async function batchSendActions(actions){
             allocationID
             amount
             poi
+            publicPOI
+            poiBlockNumber
             force
             priority
             source
@@ -388,6 +390,8 @@ async function approveActions(){
         allocationID
         amount
         poi
+        publicPOI
+        poiBlockNumber
         force
         priority
         source
@@ -437,6 +441,8 @@ async function deleteActions(){
         allocationID
         amount
         poi
+        publicPOI
+        poiBlockNumber
         force
         priority
         source
@@ -485,6 +491,8 @@ async function cancelActions(){
         allocationID
         amount
         poi
+        publicPOI
+        poiBlockNumber
         force
         priority
         source
@@ -534,6 +542,8 @@ async function queryActions(){
         allocationID
         amount
         poi
+        publicPOI
+        poiBlockNumber
         force
         priority
         source
@@ -567,6 +577,8 @@ async function executeApprovedActions(){
         allocationID
         amount
         poi
+        publicPOI
+        poiBlockNumber
         force
         source
         reason
@@ -620,6 +632,8 @@ const headers = ref([
         { title: 'Source', key: 'source'},
         { title: 'Deployment ID', key: 'deploymentID', sortable: false },
         { title: 'Allocation ID', key: 'allocationID', sortable: false },
+        { title: 'POI Block Number', key: 'poiBlockNumber' },
+        { title: 'Public POI', key: 'publicPOI' },
       ]);
 
 </script>

--- a/src/views/ActionQueueManager.vue
+++ b/src/views/ActionQueueManager.vue
@@ -347,6 +347,7 @@ async function batchSendActions(actions){
             createdAt
             updatedAt
             protocolNetwork
+            isLegacy
           }
         }
       }`,
@@ -396,6 +397,7 @@ async function approveActions(){
         createdAt
         updatedAt
         protocolNetwork
+        isLegacy
       }
     }`,
     variables: { actionIDs: selected.value.map(String) },
@@ -444,6 +446,7 @@ async function deleteActions(){
         createdAt
         updatedAt
         protocolNetwork
+        isLegacy
       }
     }`,
     variables: { actionIDs: selected.value.map(String) }
@@ -491,6 +494,7 @@ async function cancelActions(){
         createdAt
         updatedAt
         protocolNetwork
+        isLegacy
       }
     }`,
     variables: { actionIDs: selected.value.map(String) }
@@ -539,6 +543,7 @@ async function queryActions(){
         createdAt
         updatedAt
         protocolNetwork
+        isLegacy
       }
     }`,
     variables: { filter: {  } },
@@ -570,6 +575,7 @@ async function executeApprovedActions(){
         priority
         protocolNetwork
         status
+        isLegacy
       }
     }`,
   }).catch((errors) => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,7 +20,10 @@ export default defineConfig({
       },
     }),
   ],
-  define: { 'process.env': {} },
+  define: {
+    'process.env': {},
+    '__VUE_PROD_HYDRATION_MISMATCH_DETAILS__': false
+  },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))


### PR DESCRIPTION
This PR updates indexer-tools to support Graph Horizon.


### Changelog
  - Added logic to detect Horizon networks based on `maxThawingPeriod`
  - Allocations now include an `isLegacy` flag to differentiate between legacy and Horizon allocations. This is required because the agent's action queue has different processing pipelines for both.
  - Updated to support horizon manual POI management:
    - Added manual POI block height input field
    - Added manual public POI input field
    - `publicPOI` and `poiBlockNumber` are informational fields (though disputable), so we still use `poi` as the main key to determine if a POI submission needs to take manual values from the user. What this means is that the allocation wizard will ignore Public POI and block number if they are set and the main POI is not set.
  - Extended action queue to track `publicPOI`, `poiBlockNumber`, and `isLegacy` fields across all operations (allocate, reallocate, unallocate)

Note that this version of indexer tools will require a Graph Horizon compatible network subgraph, which will be made available during Phase 3 of Horizon upgrade (it won't work with the current production network subgraph).

Signed-off-by: Tomás Migone <tomas@edgeandnode.com>