### PR TITLE
Fix missing manifest handling in allocations

### DIFF
--- a/src/store/allocations.js
+++ b/src/store/allocations.js
@@ -129,7 +129,7 @@ export const useAllocationStore = defineStore('allocationStore', {
       // Network Filter
       if(state.networkFilter.length) {
         allocations = allocations.filter((i) => {
-          return i.subgraphDeployment.manifest.network && state.networkFilter.includes(i.subgraphDeployment.manifest.network);
+          return i.subgraphDeployment.manifest?.network && state.networkFilter.includes(i.subgraphDeployment.manifest.network);
         });
       }
 
@@ -210,7 +210,7 @@ export const useAllocationStore = defineStore('allocationStore', {
       for(let i = 0; i < state.allocations.length; i++){
         const deploymentStatus = deploymentStatusStore.getDeploymentStatuses[state.allocations[i].subgraphDeployment.ipfsHash];
 
-        const validChain = accountStore.getPOIQueryStatus ? chainValidation.getChainStatus[state.allocations[i].subgraphDeployment.manifest.network] : null;
+        const validChain = accountStore.getPOIQueryStatus ? chainValidation.getChainStatus[state.allocations[i].subgraphDeployment.manifest?.network] : null;
         const synced = epochStore.getBlockNumbers[state.allocations[i].subgraphDeployment.manifest?.network] <= deploymentStatus?.chains?.[0]?.latestBlock?.number;
         const deterministicFailure = synced ? null : deploymentStatus?.health == 'failed' && deploymentStatus?.fatalError && deploymentStatus?.fatalError?.deterministic == true;
 


### PR DESCRIPTION
Complete the fix for subgraphs without metadata that was partially addressed in cce9b50. The previous fix only added optional chaining to one instance of manifest.network access, but there were two additional locations that would still cause the close allocations page to break.

Changes:
- Line 132: Add optional chaining to manifest.network in network filter
- Line 213: Add optional chaining to manifest.network in validChain check

This prevents the allocation wizard's close allocations page from crashing when indexer has allocations to subgraphs missing metadata.