### PR TITLE
Upgrade Node.js version to 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Use Node 16
+# Use Node 22
 FROM node:22
 
 # Working directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use Node 16
-FROM node:16
+FROM node:22
 
 # Working directory
 WORKDIR /app


### PR DESCRIPTION
 http-proxy-middleware published v4.0.0 with a hard engines.node requirement of >=22. Because our package range resolves upward to the latest 4.x at install time, every fresh yarn run on the Node 16 base now aborts before the dependency tree finishes resolving, leaving the pod stuck in Init:CrashLoopBackOff.   